### PR TITLE
force HTTP20Connection, allow for forcing of protocol (for python 2.7)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,17 @@ Alternatively, you can create a client with the contents of the auth key file di
         use_sandbox=True
     )
 
+In Python 2.x environments, you may need to force the communication protocol to 'h2'::
+
+    client = APNsClient(
+        team_id=TEAM_ID,
+        bundle_id=BUNDLE_ID,
+        auth_key_id=APNS_KEY_ID,
+        auth_key=APNS_KEY,
+        use_sandbox=True,
+        force_proto='h2'
+    )
+
 Now you can send a message to a device by specifying its registration ID::
 
     client.send_message(

--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -7,7 +7,7 @@ import uuid
 
 from collections import namedtuple
 from contextlib import closing
-from hyper import HTTPConnection
+from hyper import HTTP20Connection
 
 from .exceptions import InternalException, ImproperlyConfigured, PayloadTooLarge
 from .utils import validate_private_key
@@ -36,7 +36,7 @@ APNSResponse = APNSResponseStruct(**APNS_RESPONSE_CODES)
 class APNsClient(object):
 
     def __init__(self, team_id, auth_key_id, 
-            auth_key=None, auth_key_filepath=None, bundle_id=None, use_sandbox=False
+            auth_key=None, auth_key_filepath=None, bundle_id=None, use_sandbox=False, force_proto=None
         ):
 
         if not (auth_key_filepath or auth_key):
@@ -57,6 +57,7 @@ class APNsClient(object):
         self.bundle_id = bundle_id
         self.auth_key = auth_key
         self.auth_key_id = auth_key_id
+        self.force_proto = force_proto
         self.host = SANDBOX_HOST if use_sandbox else PRODUCTION_HOST
 
     def send_message(self, registration_id, alert, **kwargs):
@@ -75,7 +76,7 @@ class APNsClient(object):
         return res
 
     def _create_connection(self):
-        return HTTPConnection(self.host)
+        return HTTP20Connection(self.host, force_proto=self.force_proto)
 
     def _create_token(self):
         token = jwt.encode(


### PR DESCRIPTION
I wanted to use this library (thank you for putting it together) in a Python 2.7 environment, but I was getting a ConnectionReset from hyper (http://gobiko.com/blog/connection-reset-error-hyper-debian-jessie/). However, in my case OpenSSL wasn't the culprit - it was along the lines of this hyper issue:
https://github.com/Lukasa/hyper/issues/213

The fix was simply to force the protocol over to 'h2' (and use the `HTTP20Connection` class) - which seems OK here since APNs doesn't support anything else. Basically this is just exposing the `force_proto` hyper setting to your library.