### PR TITLE
Handling exceptions in bulk_send_message

### DIFF
--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -100,7 +100,8 @@ class APNsClient(object):
                 "{good_string}\n".format(
                     bad_string="\n".join(bad_registration_ids),
                     good_string = "\n".join(good_registration_ids)
-                )
+                ),
+                bad_registration_ids
             )
 
     def _create_connection(self):

--- a/gobiko/apns/exceptions.py
+++ b/gobiko/apns/exceptions.py
@@ -31,6 +31,10 @@ class BadMessageId(APNsException):
     "The apns-id value is bad."
     pass
 
+class PartialBulkMessage(APNsException):
+    def __init__(self, message, bad_registration_ids):
+        super(APNsException, self).__init__(message)
+        self.bad_registration_ids = bad_registration_ids
 
 class BadPriority(APNsException):
     "The apns-priority value is bad."


### PR DESCRIPTION
It makes sense to allow messages that can be sent to be sent as part of the for loop in `bulk_send_message`, however, it is still prudent to bubble up an exception. I suggest that you allow the loop to continue, collect all the registration ids that are bad and is all of them are bad raise a `BadDeviceToken` else if some fail return a new `PartialBulkMessage` exception which explains which ones have failed and binds the failed ids to the exception for further processing.