### PR TITLE
Add APNsException.__str__

### DIFF
--- a/gobiko/apns/exceptions.py
+++ b/gobiko/apns/exceptions.py
@@ -1,7 +1,8 @@
 
 
 class APNsException(Exception):
-    pass
+    def __str__(self):
+        return '{e.__class__.__name__}: {e.__doc__}'.format(e=self)
 
 
 class InternalException(APNsException):


### PR DESCRIPTION
This allows to print an exception to log without accessing it's `__name__` or `__doc__`