### PR TITLE
fix send_bulk_message TooManyProviderTokenUpdates by creating auth_to…

### DIFF
--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -77,9 +77,11 @@ class APNsClient(object):
         bad_registration_ids = []
 
         with closing(self._create_connection()) as connection:
+            auth_token = self._create_token()
+
             for registration_id in registration_ids:
                 try:
-                    res = self._send_message(registration_id, alert, connection=connection, **kwargs)
+                    res = self._send_message(registration_id, alert, connection=connection, auth_token=auth_token, **kwargs)
                     good_registration_ids.append(registration_id)
                 except:
                     bad_registration_ids.append(registration_id)


### PR DESCRIPTION
Hi, I am a junior engineer from Taiwan, 
I am very grateful to have this open source pypi package.

But when I use **send_bulk_message()** and set more than two **device_token** in a list, 
I got '**TooManyProviderTokenUpdates**' response from **Apple APNs server**, 
so I try to find out what happened and modify the code to keep it working.