### PR TITLE
Allow to easily cache the auth token (extending the class)

### DIFF
--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -77,7 +77,7 @@ class APNsClient(object):
         bad_registration_ids = []
 
         with closing(self._create_connection()) as connection:
-            auth_token = self._create_token()
+            auth_token = self._get_token()
 
             for registration_id in registration_ids:
                 try:
@@ -107,6 +107,25 @@ class APNsClient(object):
                 ),
                 bad_registration_ids
             )
+
+    @staticmethod
+    def get_token_from_cache():
+        """Do not use cache by default, just provide the function to be easily overridden"""
+        return None
+
+    @staticmethod
+    def set_token_to_cache(token):
+        """Do not use cache by default, just provide the function to be easily overridden"""
+        pass
+
+    def _get_token(self):
+        token = self.get_token_from_cache()
+
+        if token is None:
+            token = self._create_token()
+            self.set_token_to_cache(token)
+
+        return token
 
     def _create_connection(self):
         return HTTP20Connection(self.host, force_proto=self.force_proto)
@@ -181,7 +200,7 @@ class APNsClient(object):
         # If expiration isn't specified use 1 month from now
         expiration_time = expiration if expiration is not None else int(time.time()) + 2592000
 
-        auth_token = auth_token or self._create_token()
+        auth_token = auth_token or self._get_token()
 
         request_headers = {
             'apns-expiration': str(expiration_time),

--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -108,12 +108,10 @@ class APNsClient(object):
                 bad_registration_ids
             )
 
-    @staticmethod
     def get_token_from_cache():
         """Do not use cache by default, just provide the function to be easily overridden"""
         return None
 
-    @staticmethod
     def set_token_to_cache(token):
         """Do not use cache by default, just provide the function to be easily overridden"""
         pass


### PR DESCRIPTION
According to [documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns#2943374) the token should get refreshed:

- no more than once every 20 minutes (TooManyProviderTokenUpdates Exception in send_bulk_message)
- no less than once every 60 minutes (TooManyRequests if using the same token again and again)

So maybe it is a good practice to allow easily cache the token extending the class and implementing the `get_token_from_cache` and `set_token_to_cache` functions.