### PR TITLE
Add apns-push-type header to support more push notification types

### DIFF
--- a/gobiko/apns/exceptions.py
+++ b/gobiko/apns/exceptions.py
@@ -13,6 +13,10 @@ class ImproperlyConfigured(APNsException):
     pass
 
 
+class InvalidPushType(APNsException):
+    pass
+
+
 class BadCollapseId(APNsException):
     "The collapse identifier exceeds the maximum allowed size"
     pass


### PR DESCRIPTION
docs at:
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947610

Tested using 'voip', 'alert' and 'background' but it should be working on other push types as well.