### PR TITLE
Decode a created token if needed

### DIFF
--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -137,7 +137,7 @@ class APNsClient(object):
                 'You must provide your bundle_id if you do not specify a topic'
             )
         
-        if not push_type in ['alert', 'silent']:
+        if push_type not in ('alert', 'silent'):
             raise ImproperlyConfigured(
                 'You must provide push_type with either a "alert" or "background" type'
             )

--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -193,7 +193,7 @@ class APNsClient(object):
             'apns-expiration': str(expiration_time),
             'apns-priority': str(priority),
             'apns-topic': topic,
-            'authorization': 'bearer {0}'.format(auth_token)
+            'authorization': 'bearer {0}'.format(auth_token),
             'apns-push-type': push_type
         }
 

--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -122,7 +122,11 @@ class APNsClient(object):
                 'kid': self.auth_key_id,
             }
         )
-        return token.decode('ascii')
+
+        if isinstance(token, bytes):
+            token = token.decode('ascii')
+
+        return token
 
     def _send_message(self, registration_id, alert, 
             badge=None, sound=None, category=None, content_available=False,

--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -129,11 +129,17 @@ class APNsClient(object):
             mutable_content=False,
             action_loc_key=None, loc_key=None, loc_args=[], extra={}, 
             identifier=None, expiration=None, priority=10, 
-            connection=None, auth_token=None, bundle_id=None, topic=None
+            connection=None, auth_token=None, bundle_id=None, topic=None, 
+            push_type='background'
         ):
         if not (topic or bundle_id or self.bundle_id):
             raise ImproperlyConfigured(
                 'You must provide your bundle_id if you do not specify a topic'
+            )
+        
+        if not push_type in ['alert', 'silent']:
+            raise ImproperlyConfigured(
+                'You must provide push_type with either a "alert" or "background" type'
             )
 
         data = {}
@@ -188,6 +194,7 @@ class APNsClient(object):
             'apns-priority': str(priority),
             'apns-topic': topic,
             'authorization': 'bearer {0}'.format(auth_token)
+            'apns-push-type': push_type
         }
 
         if not identifier:

--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -163,7 +163,7 @@ class APNsClient(object):
             raise ImproperlyConfigured(
                 'You must provide your bundle_id if you do not specify a topic'
             )
-        
+
         if push_type not in APNS_PUSH_TYPES:
             raise InvalidPushType('The push-type provided is not valid')
 

--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -164,11 +164,6 @@ class APNsClient(object):
                 'You must provide your bundle_id if you do not specify a topic'
             )
         
-        if push_type not in ('alert', 'silent'):
-            raise ImproperlyConfigured(
-                'You must provide push_type with either a "alert" or "background" type'
-            )
-
         if push_type not in APNS_PUSH_TYPES:
             raise InvalidPushType('The push-type provided is not valid')
 


### PR DESCRIPTION
If a return value of jwt.encode is bytes not str, decoding has to be done.
Because the return value is used for an authorization header value.