### PR TITLE
Fix issue when JWT creation outputs non-valid chars

### DIFF
--- a/gobiko/apns/client.py
+++ b/gobiko/apns/client.py
@@ -208,7 +208,7 @@ class APNsClient(object):
         # If expiration isn't specified use 1 month from now
         expiration_time = expiration if expiration is not None else int(time.time()) + 2592000
 
-        auth_token = auth_token or self._get_token()
+        auth_token = (auth_token or self._get_token()).decode('ascii')
 
         request_headers = {
             'apns-expiration': str(expiration_time),


### PR DESCRIPTION
In some cases the JWT creation was outputting non-base64 chars (e.g. `'`). The decoding strips those unwanted chars, while preserving the valid token.

In my particular case the output followed this:

`b'<valid JWT>'`

Using the `.decode('ascii')` one gets:

`<valid JWT>`

---

### Context

I tested both adding the .p8 as an env variable (and using its value directly) but I also tried the path approach. Both would lead to a JWT conversion with unwanted chars. 

P.S: This approach comes from your post: https://gobiko.com/blog/token-based-authentication-http2-example-apns/