### PR TITLE
Switch from hyper to httpx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cryptography==3.4.2
-hyper==0.7.0
+httpx[http2]==0.18.1
 PyJWT==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,13 @@ setup(
   url = 'https://github.com/genesluder/python-apns',
   download_url = 'https://github.com/genesluder/python-apns/tarball/0.1.6',
   keywords = [
-    'apns', 
+    'apns',
     'push notifications',
   ],
   classifiers = [],
   install_requires=[
     'cryptography<=3.3.2',
-    'hyper',
+    'httpx[http2]',
     'pyjwt',
   ],
 )


### PR DESCRIPTION
The hyper library is no longer maintained. See:
https://github.com/python-hyper/hyper/commit/b77e758f472f00b098481e3aa8651b0808524d84
Their readme suggest switching to httpx

Closes #32